### PR TITLE
fixes in stable-5.00

### DIFF
--- a/doc/001-Cross-Tools-Kernel_Headers
+++ b/doc/001-Cross-Tools-Kernel_Headers
@@ -6,7 +6,7 @@
 make mrproper
 
 # Build Headers
-ARCH=${MLFS_ARCH} make headers_check
+make ARCH=${MLFS_ARCH} headers_check
 
 # Install
-ARCH=${MLFS_ARCH} INSTALL_HDR_PATH=/cross-tools/${MLFS_TARGET} make headers_install
+make ARCH=${MLFS_ARCH} INSTALL_HDR_PATH=/cross-tools/${MLFS_TARGET} headers_install

--- a/doc/012-Tool_Chain-Adjust_Tool_Chain
+++ b/doc/012-Tool_Chain-Adjust_Tool_Chain
@@ -23,6 +23,7 @@ case $(uname -m) in
            sed -i 's/\/lib\/ld-musl-arm.so.1/\/tools\/lib\/ld-musl-arm.so.1/g' tempspecfile
            # check with
            grep "/tools/lib/ld-musl-arm.so.1" tempspecfile --color=auto
+esac
 
 mv -vf tempspecfile $SPECFILE &&
 unset SPECFILE

--- a/doc/039-Tool_Chain-Lzip
+++ b/doc/039-Tool_Chain-Lzip
@@ -13,9 +13,12 @@ export LD="${MLFS_TARGET}-ld"
 export STRIP="${MLFS_TARGET}-strip"
 
 # Configure source
-./configure --build=${MLFS_HOST} \
-            --host=${MLFS_TARGET} \
-            --prefix=/tools 
+# configure doesn't accept --host and --build flags
+./configure --prefix=/tools 
+
+# configure doesn't update g++ and tries to build with host g++
+# run sed to fix it
+sed -i 's/CXX = g++/CXX = ${MLFS_TARGET}-g++/g'
 
 # Build and Install to toolchain
 make && make install

--- a/doc/063-Final_System-Bzip2
+++ b/doc/063-Final_System-Bzip2
@@ -2,7 +2,7 @@
 # Source: http://anduin.linuxfromscratch.org/LFS/bzip2-1.0.6.tar.gz
 # This section is done in Chroot environment
 
-patch -Np1 -i ../bzip2-1.0.6-install_docs-1.patch
+patch -Np1 -i ../patches/bzip2-1.0.6-install_docs-1.patch
 sed -i 's@\(ln -s -f \)$(PREFIX)/bin/@\1@' Makefile
 sed -i "s@(PREFIX)/man@(PREFIX)/share/man@g" Makefile
 

--- a/doc/086-Final_System-Musl_FTS
+++ b/doc/086-Final_System-Musl_FTS
@@ -6,4 +6,4 @@ sed -i "/pkgconfig_DATA/i pkgconfigdir=/usr/lib/pkgconfig" Makefile.am
 ./bootstrap.sh
 
 ./configure --prefix=/usr
-make & make install
+make && make install

--- a/doc/087-Final_System-Musl_Obstack
+++ b/doc/087-Final_System-Musl_Obstack
@@ -5,4 +5,4 @@
 sed -i "/pkgconfig_DATA/i pkgconfigdir=/usr/lib/pkgconfig" Makefile.am
 ./bootstrap.sh
 ./configure --prefix=/usr
-make & make install
+make && make install

--- a/doc/096-Final_System-Meson
+++ b/doc/096-Final_System-Meson
@@ -8,4 +8,3 @@ python3 setup.py build
 # Install
 python3 setup.py install --root=dest
 cp -rv dest/* /
-~                   

--- a/doc/103-Final_System-Groff
+++ b/doc/103-Final_System-Groff
@@ -2,6 +2,9 @@
 # Source: http://ftp.gnu.org/gnu/groff/groff-1.22.4.tar.gz
 # This section is done in Chroot environment
 
-PAGE=letter ./configure --prefix=/usr
+#For users in the United States, PAGE=letter is appropriate. Elsewhere, PAGE=A4 may be more suitable.
+#It can be overridden later by echoing either `A4` or `letter` to the `/etc/papersize` file.
+
+PAGE=<paper_size> ./configure --prefix=/usr
 
 make -j1 && make install

--- a/doc/107-Final_System-IProute2
+++ b/doc/107-Final_System-IProute2
@@ -1,9 +1,9 @@
-# Final System: IProute2 5.1.0
-# Source: https://www.kernel.org/pub/linux/utils/net/iproute2/iproute2-5.1.0.tar.xz
+# Final System: IProute2 5.2.0
+# Source: https://www.kernel.org/pub/linux/utils/net/iproute2/iproute2-5.2.0.tar.xz
 # This section is done in Chroot environment
 
 sed -i /ARPD/d Makefile
 rm -fv man/man8/arpd.8
 sed -i 's/.m_ipt.o//' tc/Makefile
 
-make && make DOCDIR=/usr/share/doc/iproute2-5.1.0 instalL
+make && make DOCDIR=/usr/share/doc/iproute2-5.2.0 install

--- a/doc/118-Final_System-Eudev
+++ b/doc/118-Final_System-Eudev
@@ -1,5 +1,6 @@
 # Final System: Eudev
 # Source: https://dev.gentoo.org/~blueness/eudev/eudev-3.2.8.tar.gz
+#	: http://anduin.linuxfromscratch.org/LFS/udev-lfs-20171102.tar.xz
 # This section is done in Chroot environment
 
 cat > config.cache << "EOF"
@@ -21,6 +22,7 @@ EOF
             --config-cache
 
 LIBRARY_PATH=/tools/lib make && make LD_LIBRARY_PATH=/tools/lib install
+
 tar -xvf ../udev-lfs-20171102.tar.xz
 # Edit udev-lfs-20171102/55-lfs.rules:
 # Comment out the lines for rtc

--- a/doc/129-Final_System-Clean_up
+++ b/doc/129-Final_System-Clean_up
@@ -22,3 +22,4 @@ rm -fv /usr/lib/libfl.a
 rm -fv /usr/lib/libz.a
 find /usr/lib /usr/libexec -name \*.la -delete
 
+# It is also safe to remove /tools and /cross-tools directories as they're not required anymore


### PR DESCRIPTION
 - moved variables after `make` in `headers_check` and `headers_install` steps, otherwise the cross-tools kernel headers won't get installed under `/cross-tools/${MLFS_TARGET}`.
 - added the missing `esac` in the toolchain adjusting step for cross-tools.
 - when building `lzip`, `configure` doesn't update the `CXX` flag, causing the `make` to build with the host `g++`. added a `sed` command to manullay change `g++` to `${MLFS_TARGET}-g++`.
 - `bzip2` recipe for the final system is missing the `../patches` prefix when patching, fixed that.
 - `musl-fts` and `musl-obstack` recipes have `make & make install`, which causes `make` to install before build finishes, resulting in a make error, fixed that.
 - removed the `~` character at the end of `meson` build recipe for the final system.
 - final system `groff` recipe mentions the page size only for the united states *letter* size, added statement about the `A4` size.
 - fixed typo in the installation of the final system `iproute` and updated the package source to `5.2.0` from `5.1.0`.
 - instructions for `eudev` mentions `udev-lfs-20171102.tar.xz` but nothing points to the source link, added it.
 - added disclaimer about the `/tools` and `/cross-tools`, it is safe to delete them after the build is done as they're not needed anymore.

with these changes, i was able to build and boot properly to a working `musl+libressl` system. i didn't test `porg` or anything related to `s6` and its tools since i don't use `porg` and replaced `s6` with `sysvinit` and my own set of init scripts.