### PR TITLE
Several fixes

### DIFF
--- a/build-scripts/002-Cross-Tools-Binutils
+++ b/build-scripts/002-Cross-Tools-Binutils
@@ -9,8 +9,6 @@ mkdir -v build && cd build
    --with-sysroot=/cross-tools/${MLFS_TARGET} \
    --disable-nls --disable-multilib \
    --disable-werror \
-   --disable-ppl-version-check \
-   --disable-cloog-version-check \
    --enable-deterministic-archives \
    --disable-compressed-debug-sections &&
 make configure-host -j2 &&

--- a/build-scripts/003-Cross-Tools-GCC-Static
+++ b/build-scripts/003-Cross-Tools-GCC-Static
@@ -14,17 +14,14 @@ mkdir -v build && cd  build &&
 	  --prefix=/cross-tools --build=${MLFS_HOST} \
 	  --host=${MLFS_HOST}   --target=${MLFS_TARGET} \
 	  --with-sysroot=/cross-tools/${MLFS_TARGET} \
-	  --disable-nls  --with-newlib --without-ppl \
-	  --without-cloog      --disable-libmpx \
+	  --disable-nls  --with-newlib \
 	  --disable-libitm     --disable-libvtv \
 	  --disable-libssp     --disable-shared \
 	  --disable-libgomp    --without-headers \
 	  --disable-threads    --disable-multilib \
 	  --disable-libatomic  --disable-libstdcxx \
-	  --disable-libmudflap --disable-libcilkrts \
 	  --enable-languages=c --disable-libquadmath \
 	  --disable-libsanitizer --with-arch=${MLFS_CPU} \
-	  --disable-decimal-float --enable-clocale=generic \
-	  --disable-gnu-indirect-function &&
+	  --disable-decimal-float --enable-clocale=generic &&
 make all-gcc all-target-libgcc -j2 &&
 make install-gcc install-target-libgcc

--- a/build-scripts/005-Cross-Tools-GCC-Final
+++ b/build-scripts/005-Cross-Tools-GCC-Final
@@ -34,7 +34,6 @@ AR=ar LDFLAGS="-Wl,-rpath,/cross-tools/lib" \
     --disable-nls \
     --enable-shared \
     --enable-languages=c,c++ \
-    --enable-__cxa_atexit \
     --enable-c99 \
     --enable-long-long \
     --enable-threads=posix \
@@ -43,10 +42,7 @@ AR=ar LDFLAGS="-Wl,-rpath,/cross-tools/lib" \
     --enable-checking=release \
     --enable-fully-dynamic-string \
     --disable-symvers \
-    --disable-gnu-indirect-function \
-    --disable-libmudflap \
     --disable-libsanitizer \
-    --disable-libmpx \
     --disable-lto-plugin \
     --disable-libssp &&
 

--- a/build-scripts/009-Tool_Chain-GCC_Pass1
+++ b/build-scripts/009-Tool_Chain-GCC_Pass1
@@ -68,7 +68,6 @@ mkdir -v build && cd build &&
     --disable-threads                              \
     --disable-libatomic                            \
     --disable-libgomp                              \
-    --disable-libmpx                               \
     --disable-libquadmath                          \
     --disable-libssp                               \
     --disable-libvtv                               \
@@ -77,10 +76,7 @@ mkdir -v build && cd build &&
     --disable-libstdcxx-pch \
     --disable-symvers \
     --disable-libitm \
-    --disable-gnu-indirect-function \
-    --disable-libmudflap \
-    --disable-libsanitizer \
-    --disable-libcilkrts &&
+    --disable-libsanitizer &&
 read -p "Compile? " &&
 PATH=/bin:/usr/bin:/cross-tools/bin:/tools/bin  make -j4 &&  
 read -p "Install?" &&

--- a/build-scripts/014-Tool_Chain-GCC_Pass2
+++ b/build-scripts/014-Tool_Chain-GCC_Pass2
@@ -64,16 +64,12 @@ mkdir -v build && cd build &&
     --disable-multilib                             \
     --disable-bootstrap                            \
     --disable-libgomp \
-    --disable-libmpx                               \
     --disable-libquadmath                          \
     --disable-libssp                               \
     --disable-libvtv                               \
     --disable-symvers \
     --disable-libitm \
-    --disable-gnu-indirect-function \
-    --disable-libmudflap \
-    --disable-libsanitizer \
-    --disable-libcilkrts &&
+    --disable-libsanitizer &&
 read -p "Compile? " &&
 PATH=/bin:/usr/bin:/cross-tools/bin:/tools/bin make -j4 &&
 #make -j2 &&


### PR DESCRIPTION
I noticed that there exists several deprecated and irrelevant flags passed to both binutils and GCC's configuration scripts; hence, I removed them:

1. Everything related to PPL/CLooG was removed in favor of ISL in newer versions of binutils and GCC due to ISL being much more advanced and having a better open source licensing scheme (even the version checking flags). This means that the flags that were passed to disable version checking for both of them were removed as well.

2. `--disable-libmpx` isn't relevant as MPX support was removed from GCC starting from GCC 9:
https://gcc.gnu.org/ml/gcc-patches/2018-04/msg01225.html

3. `--disable-libmudflap` is also not relevant as the mudflap run time checker was removed starting from GCC 4.9:
https://gcc.gnu.org/gcc-4.9/changes.html

4. `--disable-gnu-indirect-function` is only relevant on systems with glibc (it's always disabled on systems that use any other libc like musl):
https://gcc.gnu.org/install/configure.html

5. `--enable-__cxa_atexit` is only available on systems with glibc:
https://gcc.gnu.org/install/configure.html

6. `--disable-libcilkrts` I couldn't find a good reason to pass this flag to GCC's configure script.