### PR TITLE
[tc-034][fs-081] perl: add patch from alpine to fix locale.c error when built using musl.

### DIFF
--- a/doc/034-Tool_Chain-Perl
+++ b/doc/034-Tool_Chain-Perl
@@ -20,6 +20,10 @@ cd perl-5.30.0 &&
 mv -v ../perl-cross-1.3/* ./
 mv -v ../perl-cross-1.3/utils/* utils/
 
+# Apply patch from Alpine to fix locale.c errors
+# in programs such as rxvt-unicode
+patch -p1 < ../patches/perl-5.30-alpine/musl-locale.patch
+
 # Configure source
 ./configure --prefix=/tools \
             --target=${MLFS_TARGET}

--- a/doc/081-Final_System-Perl
+++ b/doc/081-Final_System-Perl
@@ -9,6 +9,10 @@ export CF_OLD=$CFLAGS
 export CFLAGS+=" -DNO_POSIX_2008_LOCALE"
 export CFLAGS+=" -D_GNU_SOURCE"
 
+# Apply patch from Alpine to fix locale.c errors
+# in programs such as rxvt-unicode
+patch -p1 < ../patches/perl-5.30-alpine/musl-locale.patch
+
 sh Configure -des -Dprefix=/usr                 \
                   -Dvendorprefix=/usr           \
                   -Dman1dir=/usr/share/man/man1 \

--- a/patches/perl-5.30-alpine/musl-locale.patch
+++ b/patches/perl-5.30-alpine/musl-locale.patch
@@ -1,0 +1,37 @@
+diff --git a/locale.c b/locale.c
+index 7653340..7243cb1 100644
+--- a/locale.c
++++ b/locale.c
+@@ -581,6 +581,10 @@ S_emulate_setlocale(const int category,
+ 
+         return (char *) querylocale(mask, cur_obj);
+ 
++#  elif defined(_NL_LOCALE_NAME)
++
++        return (char *) nl_langinfo_l(_NL_LOCALE_NAME(category), cur_obj);
++
+ #  else
+ 
+         /* If this assert fails, adjust the size of curlocales in intrpvar.h */
+@@ -737,7 +741,7 @@ S_emulate_setlocale(const int category,
+ 
+     /* Here, we are switching locales. */
+ 
+-#  ifndef HAS_QUERYLOCALE
++#  if !defined(HAS_QUERYLOCALE) && !defined(_NL_LOCALE_NAME)
+ 
+     if (strEQ(locale, "")) {
+ 
+@@ -1094,6 +1098,12 @@ S_emulate_setlocale(const int category,
+         locale = querylocale(mask, new_obj);
+     }
+ 
++#  elif defined(_NL_LOCALE_NAME)
++
++    if (strEQ(locale, "")) {
++        locale = nl_langinfo_l(_NL_LOCALE_NAME(category), new_obj);
++    }
++
+ #  else
+ 
+     /* Here, 'locale' is the return value */


### PR DESCRIPTION
if one tries to build programs, such as rxvt-unicode, with a perl-5.30 that got built without the patch i've added, programs will build fine but will spit out an error complaining about `locale.c`.

[urxvt : panic: locale.c: 893: Unexpected character in locale name '2E.](https://gitlab.alpinelinux.org/alpine/aports/issues/10459)