### PR TITLE
Disable optimizations for GCC Pass 1

### DIFF
--- a/build-scripts/003-Cross-Tools-GCC-Static
+++ b/build-scripts/003-Cross-Tools-GCC-Static
@@ -10,6 +10,8 @@ mv -v gmp-6.1.2 gmp
 tar -xf ../mpc-1.1.0.tar.gz
 mv -v mpc-1.1.0 mpc
 mkdir -v build && cd  build &&
+CFLAGS='-g0 -O0' \
+CXXFLAGS='-g0 -O0' \
 ../configure \
 	  --prefix=/cross-tools --build=${MLFS_HOST} \
 	  --host=${MLFS_HOST}   --target=${MLFS_TARGET} \

--- a/build-scripts/009-Tool_Chain-GCC_Pass1
+++ b/build-scripts/009-Tool_Chain-GCC_Pass1
@@ -52,6 +52,8 @@ export LD="${MLFS_TARGET}-ld" &&
 export STRIP="${MLFS_TARGET}-strip" &&
 
 mkdir -v build && cd build &&
+CFLAGS='-g0 -O0' \
+CXXFLAGS='-g0 -O0' \
 ../configure                                       \
     --target=${MLFS_TARGET}                        \
     --build=${MLFS_HOST} \

--- a/doc/003-Cross-Tools-GCC-Static
+++ b/doc/003-Cross-Tools-GCC-Static
@@ -16,6 +16,8 @@ mv -v mpc-1.1.0 mpc
 mkdir -v build && cd  build
 
 # Configure source 
+CFLAGS='-g0 -O0' \
+CXXFLAGS='-g0 -O0' \
 ../configure \
 	  --prefix=/cross-tools --build=${MLFS_HOST} \
 	  --host=${MLFS_HOST}   --target=${MLFS_TARGET} \

--- a/doc/010-Tool_Chain-GCC_Pass1
+++ b/doc/010-Tool_Chain-GCC_Pass1
@@ -68,6 +68,8 @@ done
 
 # Configure in dedicated build directory
 mkdir -v build && cd build
+CFLAGS='-g0 -O0' \
+CXXFLAGS='-g0 -O0' \
 ../configure                                       \
     --target=${MLFS_TARGET}                        \
     --build=${MLFS_HOST} \


### PR DESCRIPTION
The first pass of GCC doesn't require optimization as it's only used to build musl (it won't be used outside of the toolchain); hence, I disabled them to significantly speed up the build process.