### PR TITLE
Fix a bug that and made dual-licensing clear

### DIFF
--- a/download_sources.sh
+++ b/download_sources.sh
@@ -2,7 +2,7 @@
 # Simple shell hack to download and MD5 check source tarballs.
 # Copyright 2021: Luiz Antônio (takusuman).
 # This particular script is dual-licensed between BSD 2-Clause
-# and GPL3, at your preference.
+# or GPL3, at your preference.
 # n() function taken from otto-pkg's posix-alt.shi lib.
 
 # USAGE: ./download_sources.sh sources.list sources.md5
@@ -26,7 +26,7 @@ main(){
 		curl -L ${urls[${i}]} -O;
 	}
 	[ ${MD5CHECK} == 'YES' ] &&
-	md5sum -c ${2};
+	md5sum -c ${PARENTDIR}/${2};
 	cd ${PARENTDIR};
 	return 0;
 }


### PR DESCRIPTION
I was porting it to CMLFS and found a small bug that disabled md5sum, which was the script trying to access the md5sum file from the src/ directory and not from the $PARENTDIR (in this our case, the repository root).