### PR TITLE
Add e to done to fix 053-Musl-Legacy-Compat

### DIFF
--- a/doc/3-Chroot/053-Musl-Legacy-Compat
+++ b/doc/3-Chroot/053-Musl-Legacy-Compat
@@ -4,4 +4,4 @@
 for h in cdefs queue tree
 do
     install -v -D -m644 files/musl-legacy-compat-void/$h.h /usr/include/sys
-don
+done


### PR DESCRIPTION
This PR fixes the script in 053-Musl-Legacy-Compat as it was missing the e in done and that would cause it to not run.