### PR TITLE
Pull request for master

### DIFF
--- a/doc/2-toolchain/04-gcc
+++ b/doc/2-toolchain/04-gcc
@@ -74,7 +74,7 @@ done
 # Configure in dedicated build directory
 mkdir -v build && cd build
 CFLAGS='-g0 -O0' \
-CXXFLAGS='-g0 -O0' \
+CXXFLAGS=$CFLAGS \
 ../configure                                       \
     --target=${MLFS_TARGET}                        \
     --build=${MLFS_HOST}                           \

--- a/doc/2-toolchain/05-kernel-headers
+++ b/doc/2-toolchain/05-kernel-headers
@@ -17,5 +17,5 @@ cp -rv usr/include/* /tools/include
 # cp -rv dest/include/* /tools/include
 
 # Remove unnecessary files for this stage:
-find /tools/include \( -name '.*' -o -name .*.cmd \) -exec rm -vf {} \;
+find /tools/include \( -name '.*' -o -name '.*.cmd' \) -exec rm -vf {} \;
 rm -v /tools/include/Makefile

--- a/doc/2-toolchain/05-kernel-headers
+++ b/doc/2-toolchain/05-kernel-headers
@@ -17,5 +17,5 @@ cp -rv usr/include/* /tools/include
 # cp -rv dest/include/* /tools/include
 
 # Remove unnecessary files for this stage:
-find /tools/include \( -name .install -o -name ..install.cmd \) -delete
+find /tools/include \( -name '.*' -o -name .*.cmd \) -exec rm -vf {} \;
 rm -v /tools/include/Makefile

--- a/doc/2-toolchain/05-kernel-headers
+++ b/doc/2-toolchain/05-kernel-headers
@@ -10,15 +10,12 @@ make mrproper
 # For kernels 5.3.x and newer:
 ARCH=${MLFS_ARCH} make headers
 
-# For kernels up to 5.2.x:
-# find dest/include \( -name .install -o -name ..install.cmd \) -delete
-
-# For kernels 5.3.x and newer:
-find usr/include \( -name .install -o -name ..install.cmd \) -delete
-
 # Install
 cp -rv usr/include/* /tools/include
-rm -v /tools/include/Makefile
 
-# for kernels up to 5.2.x:
+# ... for kernels up to 5.2.x:
 # cp -rv dest/include/* /tools/include
+
+# Remove unnecessary files for this stage:
+find /tools/include \( -name .install -o -name ..install.cmd \) -delete
+rm -v /tools/include/Makefile


### PR DESCRIPTION
## The same GCC fix that i've been doing at 04-gcc.


## Remove files from the /tools/include, not from the Kernel source at 05-kernel-headers.

.*.cmd files are essential for compiling the Linux kernel faster (see: https://www.kernel.org/doc/ols/2003/ols2003-pages-185-200.pdf at section 4 "What is new in Linux-2.5/2.6's kbuild?") as i said before in Pull request #61, so we must keep them on the sources if we're wanting to save time and disk access; so instead of removing them from the Kernel source-tree, remove from the toolchain. That's it.

## Almost forgot it! Portabilize find pipeline and in fact remove .* and .*.cmd files at 05-kernel-headers.

Haven't i did this before or i'm mistaken?

## Forgot to use `'` when calling find at 05-kernel-headers.
