### PR TITLE
Use `find`(1) insead of directly passing `/tools/lib` to `strip`(1).

### DIFF
--- a/doc/2-toolchain/34-Stripping_and_Ownership
+++ b/doc/2-toolchain/34-Stripping_and_Ownership
@@ -6,7 +6,7 @@
 # of unneeded debugging symbols.
 
 # Remove debug symbols with:
-strip --strip-debug /tools/lib/*
+find /tools/lib -type f -exec strip --strip-debug {} \;
 /usr/bin/strip --strip-unneeded /tools/{,s}bin/*
 
 # Remove the documentation:

--- a/doc/2-toolchain/34-Stripping_and_Ownership
+++ b/doc/2-toolchain/34-Stripping_and_Ownership
@@ -6,7 +6,7 @@
 # of unneeded debugging symbols.
 
 # Remove debug symbols with:
-find /tools/lib -type f -exec strip --strip-debug {} \;
+find /tools/lib -type f -exec strip --strip-unneeded {} \;
 /usr/bin/strip --strip-unneeded /tools/{,s}bin/*
 
 # Remove the documentation:

--- a/doc/3-Chroot/005-Kernel_Headers
+++ b/doc/3-Chroot/005-Kernel_Headers
@@ -19,20 +19,18 @@ patch -Np1 -i ../patches/kernel/include-uapi-linux-swab-Fix-potentially-missing-
 # For kernels 5.3.x and newer:
 make headers
 
-# There are also some hidden files used by the kernel
-# developers and not needed by MLFS that are removed
-# from the intermediate directory.
-# Kernels up to 5.2.x:
-# find dest/include \( -name .install -o -name ..install.cmd \) -exec rm -rvf {} \;
-
-# Kernels 5.3.x and newer:
-find usr/include -name '.*' -exec rm -rvf {} \;
-
 # Install Headers
 # Kernel up to 5.2.x:
 # cp -rv dest/include/* /usr/include
 
 # Kernels 5.2.x and newer:
 cp -rv usr/include/* /usr/include
-rm -v /usr/include/Makefile
 
+# After installed, there still are also some hidden
+# files used by the kernel developers (for what?)
+# and not needed by MLFS that now can be removed
+# from our /usr/include.
+find /usr/include -name '.*' -exec rm -vf {} \; 
+
+# The Makefile present also won't be used
+rm -v /usr/include/Makefile


### PR DESCRIPTION
## Use `find`(1) insead of directly passing `/tools/lib` to `strip`(1).

This prevent those "strip: Warning: foo/bar is a directory" warnings, also strips all the libraries present.

## `--strip-unneeded` instead of `--strip-debug`


## Remove `.*.cmd` and `Makefile` files from `/usr/include`, not from the Linux kernel source tree

I think we don't want to "harm" the source tree, so we won't be needing to extract the source tarball two times.
